### PR TITLE
Install epidemics from r-universe

### DIFF
--- a/renv/profiles/lesson-requirements/renv.lock
+++ b/renv/profiles/lesson-requirements/renv.lock
@@ -3,6 +3,10 @@
     "Version": "4.3.1",
     "Repositories": [
       {
+        "Name": "epiverse-trace",
+        "URL": "https://epiverse-trace.r-universe.dev"
+      },
+      {
         "Name": "carpentries",
         "URL": "https://carpentries.r-universe.dev"
       },
@@ -410,14 +414,8 @@
     "epidemics": {
       "Package": "epidemics",
       "Version": "0.0.0.9000",
-      "Source": "GitHub",
-      "RemoteType": "github",
-      "RemoteHost": "api.github.com",
-      "RemoteRepo": "epidemics",
-      "RemoteUsername": "epiverse-trace",
-      "RemotePkgRef": "epiverse-trace/epidemics",
-      "RemoteRef": "HEAD",
-      "RemoteSha": "6004c3a7e50be7b127070c4e96a011630307df17",
+      "Source": "Repository",
+      "Repository": "https://epiverse-trace.r-universe.dev",
       "Requirements": [
         "BH",
         "Rcpp",


### PR DESCRIPTION
Since the installation from GitHub is causing issues at the moment (#34), let's try switching to installing from r-universe in the interim.

An important change to note here is highlighted in our [r-universe README](https://github.com/epiverse-trace/epiverse-trace.r-universe.dev?tab=readme-ov-file#note-to-epiverse-trace-team-members): you will now have to update the version number after each change to make sure this is picked up as a new version by downstream tools.
