### PR TITLE
add note on README about deployment date and stage

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -22,6 +22,8 @@ The goal of `tutorials` is to host tutorials for Outbreak analytics with R.
 
 ## Usage
 
+> NOTE: The expected date for the deployment of the first set of tutorials is mid-November 2023
+
 Visualize this content as a webpage at <https://epiverse-trace.github.io/tutorials/>
 
 To build the website locally, please refer to [the contributing guidelines](CONTRIBUTING.md).

--- a/README.Rmd
+++ b/README.Rmd
@@ -22,7 +22,7 @@ The goal of `tutorials` is to host tutorials for Outbreak analytics with R.
 
 ## Usage
 
-> NOTE: The expected date for the deployment of the first set of tutorials is mid-November 2023
+> NOTE: The expected date for the deployment of the first set of tutorials is mid-November 2023.
 
 Visualize this content as a webpage at <https://epiverse-trace.github.io/tutorials/>
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ R.
 ## Usage
 
 > NOTE: The expected date for the deployment of the first set of
-> tutorials is mid-November 2023
+> tutorials is mid-November 2023.
 
 Visualize this content as a webpage at
 <https://epiverse-trace.github.io/tutorials/>

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ R.
 
 ## Usage
 
+> NOTE: The expected date for the deployment of the first set of
+> tutorials is mid-November 2023
+
 Visualize this content as a webpage at
 <https://epiverse-trace.github.io/tutorials/>
 


### PR DESCRIPTION
notify users about content status previous to the first deployment of episodes, until #34 gets fixed. 

I wrote mid-Nov just in case this gets longer than expected.

One question for feedback: Should we mention that tutorials are in the testing phase? I mean, add to the sentence "To review content, refer to branches `late_task_1` and `middle_task_1`"