### PR TITLE
Fixes #32 : Convert glossary to pandoc format

### DIFF
--- a/episodes/model-choices.Rmd
+++ b/episodes/model-choices.Rmd
@@ -52,7 +52,7 @@ When deciding whether an existing model can be used, we must consider :
 
 A model may already exist for your study disease, or there may be a model for an infection that has the same transmission pathways and epidemiological features that can be used. 
 
-+ Do we need a deterministic or stochastic model? 
++ Do we need a [deterministic](../learners/reference.md#deterministic) or [stochastic](../learners/reference.md#stochastic) model? 
 
 Model structures differ for whether the disease has pandemic potential or not. When predicted numbers of infection are small, stochastic variation in output can have an effect on whether an outbreak takes off or not. Outbreaks are usually smaller in magnitude than epidemics, so its often appropriate to use a stochastic model to characterise the uncertainty in the early stages of the outbreak. Epidemics are larger in magnitude than outbreaks and so a deterministic model is suitable as we have less interest in the stochastic variation in output. 
 

--- a/episodes/simulating-transmission.Rmd
+++ b/episodes/simulating-transmission.Rmd
@@ -163,7 +163,7 @@ There is a library of models to choose from in `epidemics`. Models are prefixed 
 ### Check model equations
 When using existing model structures always check the model assumptions. Ask questions such as:
 
-- How is transmission modelled? e.g. direct or indirect, airborne or vector-borne
+- How is transmission modelled? e.g. [direct](../learners/reference.md#direct) or [indirect](../learners/reference.md#indirect), [airborne](../learners/reference.md#airborne) or [vector-borne](../learners/reference.md#vectorborne)?
 - What interventions are modelled? 
 - What state variables are there and how do they relate to assumptions about infection?
 
@@ -466,7 +466,7 @@ The choice of increment will depend on the time scale of the parameters, and the
 
 ### Accounting for uncertainty 
 
-As the epidemic model is deterministic, we have one trajectory for our given parameter values. In practice, we have uncertainty in the value of our parameters. To account for this, we must run our model for different parameter combinations. 
+As the epidemic model is [deterministic](../learners/reference.md#deterministic), we have one trajectory for our given parameter values. In practice, we have uncertainty in the value of our parameters. To account for this, we must run our model for different parameter combinations. 
 
 We ran our model with $R_0= 1.5$. However, we believe that $R_0$ follows a normal distribution with mean 1.5 and standard deviation 0.05. To account for uncertainty we will run the model for different values of $R_0$. The steps we will follow to do this are:
 

--- a/learners/reference.md
+++ b/learners/reference.md
@@ -4,9 +4,8 @@ title: 'Glossary of Terms: Epiverse-TRACE'
 
 ## A
 
-#### Airborne transmission
-
-Individuals become infected via contact with infectious particles in the air. Examples include influenza, COVID-19. [More information on airborne transmission](https://www.ncbi.nlm.nih.gov/books/NBK531468/).
+[Airborne transmission]{#airborne}
+: Individuals become infected via contact with infectious particles in the air. Examples include influenza, COVID-19. [More information on airborne transmission](https://www.ncbi.nlm.nih.gov/books/NBK531468/).
 
 <!--  ## B -->
 
@@ -14,12 +13,11 @@ Individuals become infected via contact with infectious particles in the air. Ex
 
 ## D
 
-#### Deterministic models
-Models that will always have the same trajectory for given initial conditions and parameters. Examples include ordinary differential equations and difference equations. 
+[Deterministic model]{#deterministic}
+: Models that will always have the same trajectory for given initial conditions and parameters. Examples include ordinary differential equations and difference equations. 
 
-#### Direct transmission
-
-Individuals become infected via direct contact with other infected humans. Airborne transmitted infections are often modelled as directly transmitted infections as they require close contact with infected individuals for successful transmission. 
+[Direct transmission]{#direct}
+: Individuals become infected via direct contact with other infected humans. Airborne transmitted infections are often modelled as directly transmitted infections as they require close contact with infected individuals for successful transmission. 
 
 <!-- ## E -->
 
@@ -31,13 +29,11 @@ Individuals become infected via direct contact with other infected humans. Airbo
 
 ## I 
 
-#### Incubation period
+[Incubation period]{#incubation}
+: The time between becoming infected and the onset of infectiousness, same as [latent period](#latent).
 
-The time between becoming infected and the onset of infectiousness, same as 'Latent period'.
-
-#### Indirect transmission
-
-Indirectly transmitted infections are passed on to humans via contact with vectors, animals or contaminated environment. Vector-borne infections, zoonoses and water-borne infections are modelled as indirectly transmitted. 
+[Indirect transmission]{#indirect}
+: Indirectly transmitted infections are passed on to humans via contact with vectors, animals or contaminated environment. Vector-borne infections, zoonoses and water-borne infections are modelled as indirectly transmitted. 
 
 <!-- ## J -->
 
@@ -45,9 +41,8 @@ Indirectly transmitted infections are passed on to humans via contact with vecto
 
 ## L
 
-#### Latent period
-
-The time between becoming infected and the onset of infectiousness, same as 'Incubation period'.
+[Latent period]{#latent}
+: The time between becoming infected and the onset of infectiousness, same as [incubation period](#incubation).
 
 
 <!-- ## M -->
@@ -64,8 +59,8 @@ The time between becoming infected and the onset of infectiousness, same as 'Inc
 
 ## S
 
-#### Stochastic model
-A model that includes some stochastic process resulting in variation in model simulations for the same initial conditions and parameters. Examples include stochastic differential equations, branching process models. For more detail see [Allen (2017)](https://doi.org/10.1016/j.idm.2017.03.001).
+[Stochastic model]{#stochastic}
+: A model that includes some stochastic process resulting in variation in model simulations for the same initial conditions and parameters. Examples include stochastic differential equations, branching process models. For more detail see [Allen (2017)](https://doi.org/10.1016/j.idm.2017.03.001).
 
 
 <!-- ## T -->
@@ -74,8 +69,8 @@ A model that includes some stochastic process resulting in variation in model si
 
 ## V
 
-#### Vector-borne transmission 
-Vector-borne transmission means an infection can be passed from a vector (e.g. mosquitoes) to humans. Examples of vector-borne diseases include malaria and dengue. [More information on vector-borne transmission](https://www.who.int/news-room/fact-sheets/detail/vector-borne-diseases).  
+[Vector-borne transmission]{#vectorborne}
+: Vector-borne transmission means an infection can be passed from a vector (e.g. mosquitoes) to humans. Examples of vector-borne diseases include malaria and dengue. [More information on vector-borne transmission](https://www.who.int/news-room/fact-sheets/detail/vector-borne-diseases).  
 
 
 <!-- ## W -->


### PR DESCRIPTION
Updated the glossary to be pandoc format with tags and added links to tutorial text