### PR TITLE
add rebase how-to steps and one per branch suggestion

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,9 +120,9 @@ If you need the version of a package that is not programmatically loaded, i.e., 
 To merge your new episodes:
 
 - Make a Pull request (PR). You can follow the stesp on [using GitHub](#using-github).
-- Keep branches up to date with `main`. 
+- Keep your feature branch up to date with `main`. 
     - This encourage to keep the history as linear as possible, prioritizing actions like ["rebase and merge"](https://epiverse-trace.github.io/blueprints/git-branching-merging.html#merging-pull-requests-merge-commits-vs-squash-and-merge-vs-rebase-and-merge) to accept the PR.
-    - In the local repository, follow all these five steps:
+    - In the local repository. First, make sure that you are the only contributor in the `feature` branch. Then, follow all these five steps:
       1. Switch to the `main` branch: `git checkout main`
       2. Pull the `main` branch: `git pull`
       3. Switch to your `feature` branch: `git checkout feature`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,6 +130,7 @@ To merge your new episodes:
       5. Push your rebased `featured` branch using the `--force` option (this must be a forced update): `git push --force` 
     - In the remote repository, i.e. on GitHub, only if you are in a PR:
       - Update your PR branch with [Update with Rebase](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/keeping-your-pull-request-in-sync-with-the-base-branch#updating-your-pull-request-branch).
+      - To pull changes from an updated PR branch with rebase run: `git pull --rebase`
     <!-- - Go to Git tab in the environments pane. Click on `Pull options` > `Pull with rebase`.-->
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,6 +94,7 @@ install.packages(c("sandpaper", "varnish", "pegboard", "tinkr"),
 To contribute with a new episode:
 
 - [Create](https://happygitwithr.com/git-branches#create-a-new-branch) a new feature branch. Write in there your contribution.
+- Create an Issue to report the start of your WIP feature branch. Add the [WIP label](https://github.com/epiverse-trace/tutorials/labels/WIP) to it. This aims to keep one contributor per feature branch. 
 - [Create](https://carpentries.github.io/sandpaper-docs/aio.html#episodes) a new episode with `sandpaper::create_episode_md("Episode Name")`
 
 If you need to work with the most recent versions of packages:
@@ -121,9 +122,15 @@ To merge your new episodes:
 - Make a Pull request (PR). You can follow the stesp on [using GitHub](#using-github).
 - Keep branches up to date with `main`. 
     - This encourage to keep the history as linear as possible, prioritizing actions like ["rebase and merge"](https://epiverse-trace.github.io/blueprints/git-branching-merging.html#merging-pull-requests-merge-commits-vs-squash-and-merge-vs-rebase-and-merge) to accept the PR.
-    - Do this in your local repository only. In your feature branch:
-      - Go to the terminal. [Run `git pull origin main`](https://docs.gitlab.com/ee/topics/git/git_rebase.html) to rebase the feature branch.
-    - Go to Git tab in the environments pane. Click on `Pull options` > `Pull with rebase`.
+    - In the local repository:
+      - Switch to the `main` branch: `git checkout main`
+      - Pull the `main` branch: `git pull`
+      - Switch to your `feature` branch: `git checkout feature`
+      - [Rebase](https://docs.gitlab.com/ee/topics/git/git_rebase.html) your `feature` branch: `git rebase main`
+      - Push your rebased `featured` branch using the `--force` (this must be a forced update): `git push --force` 
+    - In the remote repository, i.e. on GitHub, only if you are in a PR:
+      - Update your PR branch with [Update with Rebase](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/keeping-your-pull-request-in-sync-with-the-base-branch#updating-your-pull-request-branch).
+    <!-- - Go to Git tab in the environments pane. Click on `Pull options` > `Pull with rebase`.-->
 
 
 #### Reviewer:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,17 +120,16 @@ If you need the version of a package that is not programmatically loaded, i.e., 
 To merge your new episodes:
 
 - Make a Pull request (PR). You can follow the stesp on [using GitHub](#using-github).
-- Keep your feature branch up to date with `main`. 
-    - This encourage to keep the history as linear as possible, prioritizing actions like ["rebase and merge"](https://epiverse-trace.github.io/blueprints/git-branching-merging.html#merging-pull-requests-merge-commits-vs-squash-and-merge-vs-rebase-and-merge) to accept the PR.
-    - In the local repository. First, make sure that you are the only contributor in the `feature` branch. Then, follow all these five steps:
+- If you need to get the latest commits in the `main` branch to use them in your development, we recommend rebasing your feature branch. Rebase will keep the [commit history linear](https://epiverse-trace.github.io/blueprints/git-branching-merging.html#merging-pull-requests-merge-commits-vs-squash-and-merge-vs-rebase-and-merge). First, make sure that you are the only contributor in the `feature` branch, then:
+    - In the local repository, follow all these five steps:
       1. Switch to the `main` branch: `git checkout main`
       2. Pull the `main` branch: `git pull`
       3. Switch to your `feature` branch: `git checkout feature`
       4. [Rebase](https://docs.gitlab.com/ee/topics/git/git_rebase.html) your `feature` branch onto `main` branch: `git rebase main`
       5. Push your rebased `featured` branch using the `--force` option (this must be a forced update): `git push --force` 
-    - In the remote repository, i.e. on GitHub, only if you are in a PR:
+    - In the remote repository, only if you are in a PR:
       - Update your PR branch with [Update with Rebase](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/keeping-your-pull-request-in-sync-with-the-base-branch#updating-your-pull-request-branch).
-      - To pull changes from an updated PR branch with rebase run: `git pull --rebase`
+      - To pull changes to your local repository from an updated PR branch with rebase in the remote, run: `git pull --rebase`
     <!-- - Go to Git tab in the environments pane. Click on `Pull options` > `Pull with rebase`.-->
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,12 +122,12 @@ To merge your new episodes:
 - Make a Pull request (PR). You can follow the stesp on [using GitHub](#using-github).
 - Keep branches up to date with `main`. 
     - This encourage to keep the history as linear as possible, prioritizing actions like ["rebase and merge"](https://epiverse-trace.github.io/blueprints/git-branching-merging.html#merging-pull-requests-merge-commits-vs-squash-and-merge-vs-rebase-and-merge) to accept the PR.
-    - In the local repository:
-      - Switch to the `main` branch: `git checkout main`
-      - Pull the `main` branch: `git pull`
-      - Switch to your `feature` branch: `git checkout feature`
-      - [Rebase](https://docs.gitlab.com/ee/topics/git/git_rebase.html) your `feature` branch onto `main` branch: `git rebase main`
-      - Push your rebased `featured` branch using the `--force` option (this must be a forced update): `git push --force` 
+    - In the local repository, follow all these five steps:
+      1. Switch to the `main` branch: `git checkout main`
+      2. Pull the `main` branch: `git pull`
+      3. Switch to your `feature` branch: `git checkout feature`
+      4. [Rebase](https://docs.gitlab.com/ee/topics/git/git_rebase.html) your `feature` branch onto `main` branch: `git rebase main`
+      5. Push your rebased `featured` branch using the `--force` option (this must be a forced update): `git push --force` 
     - In the remote repository, i.e. on GitHub, only if you are in a PR:
       - Update your PR branch with [Update with Rebase](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/keeping-your-pull-request-in-sync-with-the-base-branch#updating-your-pull-request-branch).
     <!-- - Go to Git tab in the environments pane. Click on `Pull options` > `Pull with rebase`.-->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,7 +126,7 @@ To merge your new episodes:
       - Switch to the `main` branch: `git checkout main`
       - Pull the `main` branch: `git pull`
       - Switch to your `feature` branch: `git checkout feature`
-      - [Rebase](https://docs.gitlab.com/ee/topics/git/git_rebase.html) your `feature` branch: `git rebase main`
+      - [Rebase](https://docs.gitlab.com/ee/topics/git/git_rebase.html) your `feature` branch onto `main` branch: `git rebase main`
       - Push your rebased `featured` branch using the `--force` (this must be a forced update): `git push --force` 
     - In the remote repository, i.e. on GitHub, only if you are in a PR:
       - Update your PR branch with [Update with Rebase](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/keeping-your-pull-request-in-sync-with-the-base-branch#updating-your-pull-request-branch).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,6 +117,7 @@ If you need the version of a package that is not programmatically loaded, i.e., 
 - [Create](https://carpentries.github.io/sandpaper/articles/building-with-renv.html#adding-new-packages-to-the-cache) an `episodes/install.R` file that lists the installation scripts for the packages in your lesson.
 - Run the `episodes/install.R` file to install the list of packages.
 - Run `sandpaper::update_cache()`. Before you accept the update, verify that the expected version number is listed as an update. After this, review the `renv.lock` file if this modified the file as expected. 
+
 To merge your new episodes:
 
 - Make a Pull request (PR). You can follow the stesp on [using GitHub](#using-github).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,7 +127,7 @@ To merge your new episodes:
       - Pull the `main` branch: `git pull`
       - Switch to your `feature` branch: `git checkout feature`
       - [Rebase](https://docs.gitlab.com/ee/topics/git/git_rebase.html) your `feature` branch onto `main` branch: `git rebase main`
-      - Push your rebased `featured` branch using the `--force` (this must be a forced update): `git push --force` 
+      - Push your rebased `featured` branch using the `--force` option (this must be a forced update): `git push --force` 
     - In the remote repository, i.e. on GitHub, only if you are in a PR:
       - Update your PR branch with [Update with Rebase](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/keeping-your-pull-request-in-sync-with-the-base-branch#updating-your-pull-request-branch).
     <!-- - Go to Git tab in the environments pane. Click on `Pull options` > `Pull with rebase`.-->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,18 +121,6 @@ If you need the version of a package that is not programmatically loaded, i.e., 
 To merge your new episodes:
 
 - Make a Pull request (PR). You can follow the stesp on [using GitHub](#using-github).
-- If you need to get the latest commits in the `main` branch to use them in your development, we recommend rebasing your feature branch. Rebase will keep the [commit history linear](https://epiverse-trace.github.io/blueprints/git-branching-merging.html#merging-pull-requests-merge-commits-vs-squash-and-merge-vs-rebase-and-merge). First, make sure that you are the only contributor in the `feature` branch, then:
-    - In the local repository, follow all these five steps:
-      1. Switch to the `main` branch: `git checkout main`
-      2. Pull the `main` branch: `git pull`
-      3. Switch to your `feature` branch: `git checkout feature`
-      4. [Rebase](https://docs.gitlab.com/ee/topics/git/git_rebase.html) your `feature` branch onto `main` branch: `git rebase main`
-      5. Push your rebased `featured` branch using the `--force` option (this must be a forced update): `git push --force` 
-    - In the remote repository, only if you are in a PR:
-      - Update your PR branch with [Update with Rebase](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/keeping-your-pull-request-in-sync-with-the-base-branch#updating-your-pull-request-branch).
-      - To pull changes to your local repository from an updated PR branch with rebase in the remote, run: `git pull --rebase`
-    <!-- - Go to Git tab in the environments pane. Click on `Pull options` > `Pull with rebase`.-->
-
 
 #### Reviewer:
 
@@ -209,6 +197,20 @@ NB: The published copy of the lesson is usually in the `main` branch.
 Each lesson has a team of maintainers who review issues and pull requests or
 encourage others to do so. The maintainers are community volunteers, and have
 final say over what gets merged into the lesson.
+
+#### Rebase
+
+- If you need to get the latest commits in the `main` branch to use them in your development, we recommend rebasing your feature branch. Rebase will keep the [commit history linear](https://epiverse-trace.github.io/blueprints/git-branching-merging.html#merging-pull-requests-merge-commits-vs-squash-and-merge-vs-rebase-and-merge). First, make sure that you are the only contributor in the `feature` branch, then:
+    - In the local repository, follow all these five steps:
+      1. Switch to the `main` branch: `git checkout main`
+      2. Pull the `main` branch: `git pull`
+      3. Switch to your `feature` branch: `git checkout feature`
+      4. [Rebase](https://docs.gitlab.com/ee/topics/git/git_rebase.html) your `feature` branch onto `main` branch: `git rebase main`
+      5. Push your rebased `featured` branch using the `--force` option (this must be a forced update): `git push --force` 
+    - In the remote repository, only if you are in a PR:
+      - Update your PR branch with [Update with Rebase](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/keeping-your-pull-request-in-sync-with-the-base-branch#updating-your-pull-request-branch).
+      - To pull changes to your local repository from an updated PR branch with rebase in the remote, run: `git pull --rebase`
+    <!-- - Go to Git tab in the environments pane. Click on `Pull options` > `Pull with rebase`.-->
 
 ### Other Resources
 


### PR DESCRIPTION
This updates the steps for:
- how to rebase in local and remote repositories.
- try to keep one contributor per feature branch.

These modifications will propagate to all workbench-based repositories.