### PR TITLE
Install sandpaper from our fork

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -78,4 +78,5 @@ profiles:
 # This space below is where custom yaml items (e.g. pinning
 # sandpaper and varnish versions) should live
 varnish: epiverse-trace/varnish@epiversetheme
-sandpaper: 'carpentries/sandpaper#533'
+# this is carpentries/sandpaper#533 in our fork so we can keep it up to date with main
+sandpaper: epiverse-trace/sandpaper@patch-renv-github-bug 


### PR DESCRIPTION
This is needed because `carpentries/sandpaper@main` contains the translation feature which is absent from the patch branch.

If we keep installing from the outdated patch branch and try to use the latest varnish version, this will result in missing text.