### PR TITLE
add citation cff draft file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,8 +10,8 @@ message: >-
   training material.
 type: dataset
 authors:
-  - given-names: Andree Adolfo
-    family-names: Valle Campos
+  - given-names: Andree
+    family-names: Valle-Campos
     email: andree.valle-campos@lshtm.ac.uk
     orcid: 'https://orcid.org/0000-0002-7779-481X'
   - given-names: Amanda

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,9 +4,10 @@
 cff-version: 1.2.0
 title: Epiverse TRACE tutorials
 message: >-
-  Please cite this tutorial using the information in this
-  file if you publish a tutorial after using this tutorial
-  or attending a training where it was taught.
+  Please cite this lesson using the information in this file
+  when you refer to it in publications, and/or if you
+  re-use, adapt, or expand on the content in your own
+  training material.
 type: dataset
 authors:
   - given-names: Andree Adolfo

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,50 @@
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+
+cff-version: 1.2.0
+title: Epiverse TRACE tutorials
+message: >-
+  Please cite this tutorial using the information in this
+  file if you publish a tutorial after using this tutorial
+  or attending a training where it was taught.
+type: dataset
+authors:
+  - given-names: Andree Adolfo
+    family-names: Valle Campos
+    email: andree.valle-campos@lshtm.ac.uk
+    orcid: 'https://orcid.org/0000-0002-7779-481X'
+  - given-names: Amanda
+    family-names: Minter
+    email: amandalminter@gmail.com
+    orcid: 'https://orcid.org/0000-0003-1171-5688'
+  - given-names: Abdoelnaser
+    family-names: Degoot
+    email: abdoelnaser-mahmood.degoot@lshtm.ac.uk
+    orcid: 'https://orcid.org/0000-0001-8788-2496'
+repository-code: 'https://github.com/epiverse-trace/tutorials/'
+url: 'https://epiverse-trace.github.io/tutorials/'
+abstract: >-
+  The Epiverse-TRACE initiative aims to provide a software
+  ecosystem for outbreak analytics with integrated,
+  generalisable and scalable community-driven software. We
+  support the development of R packages, make the existing
+  ones interoperable for the user experience, and stimulate
+  a community of practice. In the outbreak analytics
+  curriculum, we built three tutorials around an outbreak
+  analysis pipeline split into three stages: Early, Middle,
+  and Late tasks. Early tasks include reading and cleaning
+  case data and accessing delay distributions to estimate
+  transmission metrics. Middle tasks include estimating
+  forecasting, severity and superspreading from case data
+  and simulating transmission chains. Late tasks include
+  scenario modelling to simulate disease spread and
+  investigate interventions.
+keywords:
+  - outbreak analytics
+  - epidemic modelling
+  - carpentries
+  - rstats
+  - english-language
+license: CC-BY-4.0
+version: v2024-03-11
+date-released: '2024-03-11'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -46,5 +46,5 @@ keywords:
   - rstats
   - english-language
 license: CC-BY-4.0
-version: v2024-03-11
-date-released: '2024-03-11'
+version: v2025-03-11
+date-released: '2025-03-11'

--- a/README.Rmd
+++ b/README.Rmd
@@ -18,44 +18,55 @@ knitr::opts_chunk$set(
 [![Project Status: WIP - Initial development is in progress, but there has not yet been a stable, usable release suitable for the public.](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
 <!-- badges: end -->
 
-The goal of `tutorials` is to host tutorials for Outbreak analytics with R.
-
-## Usage
-
-> NOTE: The expected date for the deployment of the first set of tutorials is mid-November 2023.
-
-Visualize this content as a webpage at <https://epiverse-trace.github.io/tutorials/>
-
-To build the website locally, please refer to [the contributing guidelines](CONTRIBUTING.md).
+Tutorials on outbreak analytics and applied modelling with R developed by the Epiverse-TRACE initiative. The tutorials are visible at: <https://epiverse-trace.github.io/tutorials/>. More information about Epiverse-TRACE learning material is available at: <https://epiverse-trace.github.io/learn.html>
 
 ## Contributing
 
-Contributions are always welcome!
+Please see the [CONTRIBUTING.md](CONTRIBUTING.md) for contributing guidelines and details on how to get involved with this project. Please adhere to this project's [Code of Conduct](CODE_OF_CONDUCT.md).
 
-See our [Contributing guide](CONTRIBUTING.md) for ways to get started.
+Also see the current list of [issues](https://github.com/epiverse-trace/tutorials/issues) for ideas for contributing to this training curriculum.
 
-Please adhere to this project's [Code of Conduct](CODE_OF_CONDUCT.md).
+To learn more about how this lesson site is built and how you can edit the pages, see the [Introduction to The Carpentries Workbench](https://carpentries.github.io/sandpaper-docs/).
 
 <!-- ## Support -->
 
 <!-- Please see our [Getting help guide](/.github/SUPPORT.md) for support. -->
 
 ## License
+Lesson content is published with a [CC-BY license](LICENSE.md).
 
-Read the [License](LICENSE.md) of this tutorial.
+## Maintainer(s)
 
-## Authors
+Current maintainers of this tutorials are:
 
-- [@amanda-minter](https://github.com/amanda-minter/)
-- [@avallecam](https://github.com/avallecam/)
+- [Andree Valle-Campos](https://github.com/avallecam/) (Content)
+- [Hugo Gruson](https://github.com/Bisaloo/) (Infraestructure)
 
-```{r,eval=FALSE,echo=FALSE}
-readCitationFile(file = "inst/CITATION")
+<!--
+Former maintainers:
+
+- [Andree Valle-Campos](https://github.com/avallecam/) 
+
+-->
+
+<!--## Acknowledgements-->
+
+## Citation
+
+See [CITATION.cff](CITATION.cff) for citation information, including a list of authors.
+([Read more about the Citation File Format and how to use it](https://citation-file-format.github.io/).)
+
+To cite these tutorials in publications use:
+
+```{r,eval=TRUE,echo=FALSE}
+cffr::as_bibentry(x = "CITATION.cff")
 ```
 
-## Related projects
+A BibTeX entry for LaTeX users is:
 
-+ R package vignettes: Look at all Epiverse-TRACE packages in [our developer space](https://epiverse-trace.github.io/).
-+ [How-to guides](https://epiverse-trace.github.io/howto/): reproducible recipes with concrete steps to solve specific Outbreak Analysis questions.
-+ [The Epidemiologist R Handbook](https://www.epirhandbook.com/en/index.html): Quick R code reference manual with task-centered examples that address common epidemiological problems.
-+ *COMING SOON* case studies: reproducible case-studies of outbreak data analysis tasks using R packages.
+```{r,eval=TRUE,echo=FALSE}
+utils::toBibtex(cffr::as_bibentry(x = "CITATION.cff"))
+```
+
+## Contact
+Please get in touch with [Andree Valle-Campos](mailto:andree.valle-campos@lshtm.ac.uk) with any questions about this tutorial.

--- a/README.Rmd
+++ b/README.Rmd
@@ -53,6 +53,16 @@ Former maintainers:
 
 <!--## Acknowledgements-->
 
+## Related documentation
+
++ [How-to guides](https://epiverse-trace.github.io/howto/): Reproducible recipes with concrete steps to solve specific Outbreak Analysis questions using multiple packages.
++ [Reference manuals and vignettes](https://epiverse-trace.github.io/getting-started.html#epiverse-trace-packages): Package-specific usage guides and function examples, along with explanatory articles.
+
+## Related learning materials
+
++ [Introductory R tutorials](https://appliedepi.org/resources/tutorials.html): Refresh your R knowledge with interactive online self-paced tutorials from the Applied Epi organization.
++ [The Epidemiologist R Handbook](https://www.epirhandbook.com/en/index.html): Online book on basics, data management, epidemiological analysis, visualization, and reporting from the Applied Epi organization.
+
 ## Citation
 
 See [CITATION.cff](CITATION.cff) for citation information, including a list of authors.

--- a/README.Rmd
+++ b/README.Rmd
@@ -53,12 +53,14 @@ Former maintainers:
 
 <!--## Acknowledgements-->
 
-## Related documentation
+## Related
+
+Epiverse-TRACE documentation:
 
 + [How-to guides](https://epiverse-trace.github.io/howto/): Reproducible recipes with concrete steps to solve specific Outbreak Analysis questions using multiple packages.
 + [Reference manuals and vignettes](https://epiverse-trace.github.io/getting-started.html#epiverse-trace-packages): Package-specific usage guides and function examples, along with explanatory articles.
 
-## Related learning materials
+Preliminary learning materials:
 
 + [Introductory R tutorials](https://appliedepi.org/resources/tutorials.html): Refresh your R knowledge with interactive online self-paced tutorials from the Applied Epi organization.
 + [The Epidemiologist R Handbook](https://www.epirhandbook.com/en/index.html): Online book on basics, data management, epidemiological analysis, visualization, and reporting from the Applied Epi organization.

--- a/README.Rmd
+++ b/README.Rmd
@@ -18,13 +18,15 @@ knitr::opts_chunk$set(
 [![Project Status: WIP - Initial development is in progress, but there has not yet been a stable, usable release suitable for the public.](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
 <!-- badges: end -->
 
-Tutorials on outbreak analytics and applied modelling with R developed by the Epiverse-TRACE initiative. The tutorials are visible at: <https://epiverse-trace.github.io/tutorials/>. More information about Epiverse-TRACE learning material is available at: <https://epiverse-trace.github.io/learn.html>
+Tutorials on outbreak analytics and applied modelling with R developed by the Epiverse-TRACE initiative. These tutorials are visible at: <https://epiverse-trace.github.io/tutorials/>. 
+
+More information about Epiverse-TRACE learning material is available at: <https://epiverse-trace.github.io/learn.html>
 
 ## Contributing
 
 Please see the [CONTRIBUTING.md](CONTRIBUTING.md) for contributing guidelines and details on how to get involved with this project. Please adhere to this project's [Code of Conduct](CODE_OF_CONDUCT.md).
 
-Also see the current list of [issues](https://github.com/epiverse-trace/tutorials/issues) for ideas for contributing to this training curriculum.
+Also see the current list of [issues](https://github.com/epiverse-trace/tutorials/issues) for ideas on how to contribute to this training curriculum.
 
 To learn more about how this lesson site is built and how you can edit the pages, see the [Introduction to The Carpentries Workbench](https://carpentries.github.io/sandpaper-docs/).
 
@@ -37,7 +39,7 @@ Lesson content is published with a [CC-BY license](LICENSE.md).
 
 ## Maintainer(s)
 
-Current maintainers of this tutorials are:
+Current maintainers of these tutorials are:
 
 - [Andree Valle-Campos](https://github.com/avallecam/) (Content)
 - [Hugo Gruson](https://github.com/Bisaloo/) (Infrastructure)
@@ -69,4 +71,4 @@ utils::toBibtex(cffr::as_bibentry(x = "CITATION.cff"))
 ```
 
 ## Contact
-Please get in touch with [Andree Valle-Campos](mailto:andree.valle-campos@lshtm.ac.uk) with any questions about this tutorial.
+Please contact [Andree Valle-Campos](mailto:andree.valle-campos@lshtm.ac.uk) with any questions about this tutorial.

--- a/README.Rmd
+++ b/README.Rmd
@@ -40,7 +40,7 @@ Lesson content is published with a [CC-BY license](LICENSE.md).
 Current maintainers of this tutorials are:
 
 - [Andree Valle-Campos](https://github.com/avallecam/) (Content)
-- [Hugo Gruson](https://github.com/Bisaloo/) (Infraestructure)
+- [Hugo Gruson](https://github.com/Bisaloo/) (Infrastructure)
 
 <!--
 Former maintainers:
@@ -58,13 +58,13 @@ See [CITATION.cff](CITATION.cff) for citation information, including a list of a
 
 To cite these tutorials in publications use:
 
-```{r,eval=TRUE,echo=FALSE}
+```{r,eval=TRUE,echo=FALSE,comment=""}
 cffr::as_bibentry(x = "CITATION.cff")
 ```
 
 A BibTeX entry for LaTeX users is:
 
-```{r,eval=TRUE,echo=FALSE}
+```{r,eval=TRUE,echo=FALSE,comment=""}
 utils::toBibtex(cffr::as_bibentry(x = "CITATION.cff"))
 ```
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Lesson content is published with a [CC-BY license](LICENSE.md).
 Current maintainers of this tutorials are:
 
 - [Andree Valle-Campos](https://github.com/avallecam/) (Content)
-- [Hugo Gruson](https://github.com/Bisaloo/) (Infraestructure)
+- [Hugo Gruson](https://github.com/Bisaloo/) (Infrastructure)
 
 <!--
 Former maintainers:
@@ -59,20 +59,20 @@ use it](https://citation-file-format.github.io/).)
 
 To cite these tutorials in publications use:
 
-    #> Valle Campos A, Minter A, Degoot A (2025). "Epiverse TRACE tutorials."
-    #> <https://epiverse-trace.github.io/tutorials/>.
+    Valle Campos A, Minter A, Degoot A (2025). "Epiverse TRACE tutorials."
+    <https://epiverse-trace.github.io/tutorials/>.
 
 A BibTeX entry for LaTeX users is:
 
-    #> @Misc{vallecampos_etall:2025,
-    #>   title = {Epiverse TRACE tutorials},
-    #>   author = {Andree Adolfo {Valle Campos} and Amanda Minter and Abdoelnaser Degoot},
-    #>   year = {2025},
-    #>   url = {https://epiverse-trace.github.io/tutorials/},
-    #>   abstract = {The Epiverse-TRACE initiative aims to provide a software ecosystem for outbreak analytics with integrated, generalisable and scalable community-driven software. We support the development of R packages, make the existing ones interoperable for the user experience, and stimulate a community of practice. In the outbreak analytics curriculum, we built three tutorials around an outbreak analysis pipeline split into three stages: Early, Middle, and Late tasks. Early tasks include reading and cleaning case data and accessing delay distributions to estimate transmission metrics. Middle tasks include estimating forecasting, severity and superspreading from case data and simulating transmission chains. Late tasks include scenario modelling to simulate disease spread and investigate interventions.},
-    #>   keywords = {outbreak analytics,epidemic modelling,carpentries,rstats,english-language},
-    #>   version = {v2025-03-11},
-    #> }
+    @Misc{vallecampos_etall:2025,
+      title = {Epiverse TRACE tutorials},
+      author = {Andree Adolfo {Valle Campos} and Amanda Minter and Abdoelnaser Degoot},
+      year = {2025},
+      url = {https://epiverse-trace.github.io/tutorials/},
+      abstract = {The Epiverse-TRACE initiative aims to provide a software ecosystem for outbreak analytics with integrated, generalisable and scalable community-driven software. We support the development of R packages, make the existing ones interoperable for the user experience, and stimulate a community of practice. In the outbreak analytics curriculum, we built three tutorials around an outbreak analysis pipeline split into three stages: Early, Middle, and Late tasks. Early tasks include reading and cleaning case data and accessing delay distributions to estimate transmission metrics. Middle tasks include estimating forecasting, severity and superspreading from case data and simulating transmission chains. Late tasks include scenario modelling to simulate disease spread and investigate interventions.},
+      keywords = {outbreak analytics,epidemic modelling,carpentries,rstats,english-language},
+      version = {v2025-03-11},
+    }
 
 ## Contact
 

--- a/README.md
+++ b/README.md
@@ -11,50 +11,71 @@ has not yet been a stable, usable release suitable for the
 public.](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
 <!-- badges: end -->
 
-The goal of `tutorials` is to host tutorials for Outbreak analytics with
-R.
-
-## Usage
-
-> NOTE: The expected date for the deployment of the first set of
-> tutorials is mid-November 2023.
-
-Visualize this content as a webpage at
-<https://epiverse-trace.github.io/tutorials/>
-
-To build the website locally, please refer to [the contributing
-guidelines](CONTRIBUTING.md).
+Tutorials on outbreak analytics and applied modelling with R developed
+by the Epiverse-TRACE initiative. The tutorials are visible at:
+<https://epiverse-trace.github.io/tutorials/>. More information about
+Epiverse-TRACE learning material is available at:
+<https://epiverse-trace.github.io/learn.html>
 
 ## Contributing
 
-Contributions are always welcome!
+Please see the [CONTRIBUTING.md](CONTRIBUTING.md) for contributing
+guidelines and details on how to get involved with this project. Please
+adhere to this project’s [Code of Conduct](CODE_OF_CONDUCT.md).
 
-See our [Contributing guide](CONTRIBUTING.md) for ways to get started.
+Also see the current list of
+[issues](https://github.com/epiverse-trace/tutorials/issues) for ideas
+for contributing to this training curriculum.
 
-Please adhere to this project’s [Code of Conduct](CODE_OF_CONDUCT.md).
+To learn more about how this lesson site is built and how you can edit
+the pages, see the [Introduction to The Carpentries
+Workbench](https://carpentries.github.io/sandpaper-docs/).
 
 <!-- ## Support -->
 <!-- Please see our [Getting help guide](/.github/SUPPORT.md) for support. -->
 
 ## License
 
-Read the [License](LICENSE.md) of this tutorial.
+Lesson content is published with a [CC-BY license](LICENSE.md).
 
-## Authors
+## Maintainer(s)
 
-- [@amanda-minter](https://github.com/amanda-minter/)
-- [@avallecam](https://github.com/avallecam/)
+Current maintainers of this tutorials are:
 
-## Related projects
+- [Andree Valle-Campos](https://github.com/avallecam/) (Content)
+- [Hugo Gruson](https://github.com/Bisaloo/) (Infraestructure)
 
-- R package vignettes: Look at all Epiverse-TRACE packages in [our
-  developer space](https://epiverse-trace.github.io/).
-- [How-to guides](https://epiverse-trace.github.io/howto/): reproducible
-  recipes with concrete steps to solve specific Outbreak Analysis
-  questions.
-- [The Epidemiologist R
-  Handbook](https://www.epirhandbook.com/en/index.html): Quick R code
-  reference manual with task-centered examples that address common
-  epidemiological problems.
-- *COMING SOON* case studies: reproducible case-studies of outbreak data
-  analysis tasks using R packages.
+<!--
+Former maintainers:
+&#10;- [Andree Valle-Campos](https://github.com/avallecam/) 
+&#10;-->
+<!--## Acknowledgements-->
+
+## Citation
+
+See [CITATION.cff](CITATION.cff) for citation information, including a
+list of authors. ([Read more about the Citation File Format and how to
+use it](https://citation-file-format.github.io/).)
+
+To cite these tutorials in publications use:
+
+    #> Valle Campos A, Minter A, Degoot A (2025). "Epiverse TRACE tutorials."
+    #> <https://epiverse-trace.github.io/tutorials/>.
+
+A BibTeX entry for LaTeX users is:
+
+    #> @Misc{vallecampos_etall:2025,
+    #>   title = {Epiverse TRACE tutorials},
+    #>   author = {Andree Adolfo {Valle Campos} and Amanda Minter and Abdoelnaser Degoot},
+    #>   year = {2025},
+    #>   url = {https://epiverse-trace.github.io/tutorials/},
+    #>   abstract = {The Epiverse-TRACE initiative aims to provide a software ecosystem for outbreak analytics with integrated, generalisable and scalable community-driven software. We support the development of R packages, make the existing ones interoperable for the user experience, and stimulate a community of practice. In the outbreak analytics curriculum, we built three tutorials around an outbreak analysis pipeline split into three stages: Early, Middle, and Late tasks. Early tasks include reading and cleaning case data and accessing delay distributions to estimate transmission metrics. Middle tasks include estimating forecasting, severity and superspreading from case data and simulating transmission chains. Late tasks include scenario modelling to simulate disease spread and investigate interventions.},
+    #>   keywords = {outbreak analytics,epidemic modelling,carpentries,rstats,english-language},
+    #>   version = {v2025-03-11},
+    #> }
+
+## Contact
+
+Please get in touch with [Andree
+Valle-Campos](mailto:andree.valle-campos@lshtm.ac.uk) with any questions
+about this tutorial.

--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ public.](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostat
 <!-- badges: end -->
 
 Tutorials on outbreak analytics and applied modelling with R developed
-by the Epiverse-TRACE initiative. The tutorials are visible at:
-<https://epiverse-trace.github.io/tutorials/>. More information about
-Epiverse-TRACE learning material is available at:
+by the Epiverse-TRACE initiative. These tutorials are visible at:
+<https://epiverse-trace.github.io/tutorials/>.
+
+More information about Epiverse-TRACE learning material is available at:
 <https://epiverse-trace.github.io/learn.html>
 
 ## Contributing
@@ -25,7 +26,7 @@ adhere to this project’s [Code of Conduct](CODE_OF_CONDUCT.md).
 
 Also see the current list of
 [issues](https://github.com/epiverse-trace/tutorials/issues) for ideas
-for contributing to this training curriculum.
+on how to contribute to this training curriculum.
 
 To learn more about how this lesson site is built and how you can edit
 the pages, see the [Introduction to The Carpentries
@@ -40,7 +41,7 @@ Lesson content is published with a [CC-BY license](LICENSE.md).
 
 ## Maintainer(s)
 
-Current maintainers of this tutorials are:
+Current maintainers of these tutorials are:
 
 - [Andree Valle-Campos](https://github.com/avallecam/) (Content)
 - [Hugo Gruson](https://github.com/Bisaloo/) (Infrastructure)
@@ -59,14 +60,14 @@ use it](https://citation-file-format.github.io/).)
 
 To cite these tutorials in publications use:
 
-    Valle Campos A, Minter A, Degoot A (2025). "Epiverse TRACE tutorials."
+    Valle-Campos A, Minter A, Degoot A (2025). "Epiverse TRACE tutorials."
     <https://epiverse-trace.github.io/tutorials/>.
 
 A BibTeX entry for LaTeX users is:
 
     @Misc{vallecampos_etall:2025,
       title = {Epiverse TRACE tutorials},
-      author = {Andree Adolfo {Valle Campos} and Amanda Minter and Abdoelnaser Degoot},
+      author = {Andree Valle-Campos and Amanda Minter and Abdoelnaser Degoot},
       year = {2025},
       url = {https://epiverse-trace.github.io/tutorials/},
       abstract = {The Epiverse-TRACE initiative aims to provide a software ecosystem for outbreak analytics with integrated, generalisable and scalable community-driven software. We support the development of R packages, make the existing ones interoperable for the user experience, and stimulate a community of practice. In the outbreak analytics curriculum, we built three tutorials around an outbreak analysis pipeline split into three stages: Early, Middle, and Late tasks. Early tasks include reading and cleaning case data and accessing delay distributions to estimate transmission metrics. Middle tasks include estimating forecasting, severity and superspreading from case data and simulating transmission chains. Late tasks include scenario modelling to simulate disease spread and investigate interventions.},
@@ -76,6 +77,6 @@ A BibTeX entry for LaTeX users is:
 
 ## Contact
 
-Please get in touch with [Andree
+Please contact [Andree
 Valle-Campos](mailto:andree.valle-campos@lshtm.ac.uk) with any questions
 about this tutorial.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,27 @@ Former maintainers:
 &#10;-->
 <!--## Acknowledgements-->
 
+## Related documentation
+
+- [How-to guides](https://epiverse-trace.github.io/howto/): Reproducible
+  recipes with concrete steps to solve specific Outbreak Analysis
+  questions using multiple packages.
+- [Reference manuals and
+  vignettes](https://epiverse-trace.github.io/getting-started.html#epiverse-trace-packages):
+  Package-specific usage guides and function examples, along with
+  explanatory articles.
+
+## Related learning materials
+
+- [Introductory R
+  tutorials](https://appliedepi.org/resources/tutorials.html): Refresh
+  your R knowledge with interactive online self-paced tutorials from the
+  Applied Epi organization.
+- [The Epidemiologist R
+  Handbook](https://www.epirhandbook.com/en/index.html): Online book on
+  basics, data management, epidemiological analysis, visualization, and
+  reporting from the Applied Epi organization.
+
 ## Citation
 
 See [CITATION.cff](CITATION.cff) for citation information, including a

--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@ Former maintainers:
 &#10;-->
 <!--## Acknowledgements-->
 
-## Related documentation
+## Related
+
+Epiverse-TRACE documentation:
 
 - [How-to guides](https://epiverse-trace.github.io/howto/): Reproducible
   recipes with concrete steps to solve specific Outbreak Analysis
@@ -62,7 +64,7 @@ Former maintainers:
   Package-specific usage guides and function examples, along with
   explanatory articles.
 
-## Related learning materials
+Preliminary learning materials:
 
 - [Introductory R
   tutorials](https://appliedepi.org/resources/tutorials.html): Refresh


### PR DESCRIPTION
Fix #37 

Goal:
- Write a template CFF citation file to reuse to each `early`, `middle`, and `late` tutorials

Methods:
- https://carpentries.org/blog/2024/07/lesson-cffs/
- https://carpentries.github.io/lesson-development-training/collaborating-newcomers.html#templates-for-collaboration

To Do list:
- [x] write draft citation CFF file 
- [x] rewrite/update the README file
- [ ] Review status of #169 

The output is nicely visible in the [branch README](https://github.com/epiverse-trace/tutorials/tree/add-citation-cff?tab=readme-ov-file#tutorials).